### PR TITLE
Grey box of Spheres and Rosenbrock 

### DIFF
--- a/AMaLGaM/AMaLGaM-Full.c
+++ b/AMaLGaM/AMaLGaM-Full.c
@@ -1416,8 +1416,8 @@ void sphereFunctionProblemEvaluation( double *parameters, int population_index, 
   result += (parameters[0] * parameters[0]) - (current_best[population_index] * current_best[population_index]);
   // printf("\ncurrent opt: %lf\n", current_opt);
   // printf("Current best: %lf\n", current_best[population_index]);
-  printf("Paramater: %lf\n", parameters[0]);
-  printf("result: %lf\n\n", result);
+  // printf("Paramater: %lf\n", parameters[0]);
+  // printf("result: %lf\n\n", result);
 
   for (int i = 0; i < total_amount_of_parameters; i++) {
     printf("(%lf) ^ 2 + ",current_best[i]);
@@ -1587,25 +1587,39 @@ void rosenbrockFunctionProblemEvaluation( double *parameters, int population_ind
   int    i;
   double result;
 
-  double *values = (double *) Malloc( total_amount_of_parameters*sizeof( double ) );
+  result = current_opt;
 
-  for (int g = 0; g < total_amount_of_parameters; g++ ) {
-    values[g] = current_best[g];
+
+  printf("Paramater: %lf at %d\n", parameters[0], population_index);
+
+  for (int i = 0; i < total_amount_of_parameters; i++) {
+    printf("%lf, ",current_best[i]);
   }
 
-  for (int k = 0; k < number_of_parameters; k++ ) {
-    values[k + population_index] = parameters[k];
+
+  if (population_index != 0) {
+    double x_previous = current_best[population_index - 1];
+    double x_old = current_best[population_index];
+    double new_value = 100*(parameters[0]-x_previous*x_previous)*(parameters[0]-x_previous*x_previous) + (1.0-x_previous)*(1.0-x_previous);
+    double old_value = 100*(x_old-x_previous*x_previous)*(x_old-x_previous*x_previous) + (1.0-x_previous)*(1.0-x_previous);
+
+    result += new_value - old_value;
   }
 
-  result = 0.0;
-  for( i = 0; i < total_amount_of_parameters-1; i++ ) {
-      result += 100*(values[i+1]-values[i]*values[i])*(values[i+1]-values[i]*values[i]) + (1.0-values[i])*(1.0-values[i]);
+  if (population_index != total_amount_of_parameters )  {
+    double x_next = current_best[population_index + 1];
+    double x_old = current_best[population_index];
+    double new_value = 100*(x_next-parameters[0]*parameters[0])*(x_next-parameters[0]*parameters[0]) + (1.0-parameters[0])*(1.0-parameters[0]);
+    double old_value = 100*(x_next-x_old*x_old)*(x_next-x_old*x_old) + (1.0-x_old)*(1.0-x_old);
+
+    result += new_value - old_value;
   }
 
   *objective_value  = result;
   *constraint_value = 0;
 
-  free(values);
+  printf("obj value: %lf\n\n", *objective_value);
+
 }
 
 double rosenbrockFunctionLowerRangeBound( int dimension )
@@ -1944,6 +1958,14 @@ void initializeDistributionMultipliers( void )
   distribution_multiplier_increase = 1.0/distribution_multiplier_decrease;
 }
 
+void set_base_fitness() {
+    switch( problem_index )
+    {
+      case  7: current_opt = 9;
+      default: current_opt = 0;
+    }
+}
+
 /**
  * Initializes the populations and the fitness values.
  */
@@ -1952,6 +1974,8 @@ void initializePopulationsAndFitnessValues( void )
   int     i, j, k, o, q, *sorted, ssize, j_min, *temporary_population_sizes;
   double *distances, d, d_min, **solutions, *fitnesses, *constraints, **leader_vectors;
 
+  set_base_fitness();
+  
   for( i = 0; i < number_of_populations; i++ )
   {
     for( j = 0; j < population_size; j++ )
@@ -3016,7 +3040,7 @@ void generateAndEvaluateNewSolutionsToFillPopulations( void )
 
 
     for (int i = 0; i < total_amount_of_parameters; i++) {
-      printf("(%lf) ^ 2 + \n",current_best[i]);
+      printf("%lf, \n",current_best[i]);
     }
 
 

--- a/AMaLGaM/AMaLGaM-Full.c
+++ b/AMaLGaM/AMaLGaM-Full.c
@@ -1414,10 +1414,6 @@ void sphereFunctionProblemEvaluation( double *parameters, int population_index, 
 
   // Use own parameters for the related values
   result += (parameters[0] * parameters[0]) - (current_best[population_index] * current_best[population_index]);
-  // printf("\ncurrent opt: %lf\n", current_opt);
-  // printf("Current best: %lf\n", current_best[population_index]);
-  // printf("Paramater: %lf\n", parameters[0]);
-  // printf("result: %lf\n\n", result);
 
   for (int i = 0; i < total_amount_of_parameters; i++) {
     printf("(%lf) ^ 2 + ",current_best[i]);
@@ -1589,14 +1585,6 @@ void rosenbrockFunctionProblemEvaluation( double *parameters, int population_ind
 
   result = current_opt;
 
-
-  printf("Paramater: %lf at %d\n", parameters[0], population_index);
-
-  for (int i = 0; i < total_amount_of_parameters; i++) {
-    printf("%lf, ",current_best[i]);
-  }
-
-
   if (population_index != 0) {
     double x_previous = current_best[population_index - 1];
     double x_old = current_best[population_index];
@@ -1617,9 +1605,6 @@ void rosenbrockFunctionProblemEvaluation( double *parameters, int population_ind
 
   *objective_value  = result;
   *constraint_value = 0;
-
-  printf("obj value: %lf\n\n", *objective_value);
-
 }
 
 double rosenbrockFunctionLowerRangeBound( int dimension )
@@ -1961,8 +1946,9 @@ void initializeDistributionMultipliers( void )
 void set_base_fitness() {
     switch( problem_index )
     {
-      case  7: current_opt = 9;
-      default: current_opt = 0;
+      case  7: {
+        current_opt = total_amount_of_parameters - 1; break;
+      }
     }
 }
 
@@ -1975,7 +1961,7 @@ void initializePopulationsAndFitnessValues( void )
   double *distances, d, d_min, **solutions, *fitnesses, *constraints, **leader_vectors;
 
   set_base_fitness();
-  
+
   for( i = 0; i < number_of_populations; i++ )
   {
     for( j = 0; j < population_size; j++ )
@@ -3034,24 +3020,6 @@ void generateAndEvaluateNewSolutionsToFillPopulations( void )
     }
     // Edited: Update global current_best array for any values found.
 
-
-
-
-
-
-    for (int i = 0; i < total_amount_of_parameters; i++) {
-      printf("%lf, \n",current_best[i]);
-    }
-
-
-      for(int z = 0; z < population_size; z++){
-        printf("Objective valuess list: %lf at %d\n", objective_values[i][sorted[z]], sorted[z]);
-      }
-
-
-     printf("objc opt: %lf\n", objective_values[i][sorted[1]]);
-     printf("current opt: %lf\n\n", current_opt);
-
     free( sorted );
 
   }
@@ -3452,8 +3420,9 @@ void run( void )
    ezilaitini();
 
    // Edited: Print current best at the end of process to check whether we did indeed find the best values
+   printf("Final results: (Debug purposes)");
    for (int i = 0; i < total_amount_of_parameters; i++) {
-     printf("(%lf) ^ 2 + \n",current_best[i]);
+     printf("%lf,  \n",current_best[i]);
    }
 }
 /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/

--- a/AMaLGaM/AMaLGaM-Full.c
+++ b/AMaLGaM/AMaLGaM-Full.c
@@ -892,7 +892,7 @@ void interpretCommandLine( int argc, char **argv )
   if( use_guidelines )
   {
     tau                              = 0.35;
-    population_size                  = (int) (17.0 + 3.0*pow((double) number_of_parameters,1.5));
+    //population_size                  = (int) (17.0 + 3.0*pow((double) number_of_parameters,1.5));
     distribution_multiplier_decrease = 0.9;
     st_dev_ratio_threshold           = 1.0;
     maximum_no_improvement_stretch   = 25 + number_of_parameters;
@@ -1415,14 +1415,8 @@ void sphereFunctionProblemEvaluation( double *parameters, int population_index, 
   // Use own parameters for the related values
   result += (parameters[0] * parameters[0]) - (current_best[population_index] * current_best[population_index]);
 
-  for (int i = 0; i < total_amount_of_parameters; i++) {
-    printf("(%lf) ^ 2 + ",current_best[i]);
-  }
-
   *objective_value  = result;
   *constraint_value = 0;
-
-  printf("obj value: %lf\n\n", *objective_value);
 }
 
 double sphereFunctionProblemLowerRangeBound( int dimension )

--- a/AMaLGaM/AMaLGaM-Full.c
+++ b/AMaLGaM/AMaLGaM-Full.c
@@ -1767,23 +1767,24 @@ void sumOfRotatedEllipsoidBlocksFunctionProblemEvaluation( double *parameters, i
 
   result = current_opt;
 
-  printf("Current Opt Result: %lf\n", current_opt);
-
-  printf("Final results: (Debug purposes)\n");
-  for (int i = 0; i < block_size; i++) {
-    printf("old values: %lf,  \n", current_best[(population_index * block_size) + i]);
-    printf("new values: %lf,  \n", parameters[i]);
-  }
+  // printf("Current Opt Result: %lf\n", current_opt);
+  //
+  // printf("Final results: (Debug purposes)\n");
+  // for (int i = 0; i < block_size; i++) {
+  //   printf("old values: %lf,  \n", current_best[(population_index * block_size) + i]);
+  //   printf("new values: %lf,  \n", parameters[i]);
+  // }
 
   double old_value = sumOfRotatedEllipsoidCalculateResult(&current_best[population_index * block_size], block_size, cond_factor);
   double new_value = sumOfRotatedEllipsoidCalculateResult(parameters, block_size, cond_factor);
 
-  printf("old: %lf\n", old_value);
-  printf("new: %lf\n", new_value);
+  // printf("old: %lf\n", old_value);
+  // printf("new: %lf\n", new_value);
 
   result += new_value - old_value;
 
-  printf("New Result: %lf\n", result);
+  // printf("New Result: %lf\n", result);
+  // printf("Current Opt: %lf\n", current_opt);
 
 
   *objective_value  = result;
@@ -2987,7 +2988,7 @@ void generateAndEvaluateNewSolutionsToFillPopulations( void )
       samples_drawn_from_normal[i] = 0;
       out_of_bounds_draws[i]       = 0;
       q                            = 0;
-      for( j = 1; j < population_size; j++ )
+      for( j = 0; j < population_size; j++ )
       {
         solution = generateNewSolution( i );
 
@@ -3032,10 +3033,10 @@ void generateAndEvaluateNewSolutionsToFillPopulations( void )
 
     if (current_opt > objective_values[i][sorted[1]]) {
       for (int f = 0; f < number_of_parameters; f++ ) {
-        current_best[(i * number_of_parameters) + f] = populations[i][sorted[1]][f];
+        current_best[(i * number_of_parameters) + f] = populations[i][sorted[0]][f];
       }
 
-      current_opt = objective_values[i][sorted[1]];
+      current_opt = objective_values[i][sorted[0]];
     }
     // Edited: Update global current_best array for any values found.
 


### PR DESCRIPTION
This PR is currently based on BBO to clearly showcase the changes I've made.
Before this PR is merged we should rename this file to be able to run benchmarks on both BBO and GBO.


### Sphere
`program.exe -v -g 0 1 -100 100 0 0 0 10 0 0 1000000 -2 0 0.5 10`

`program.exe -v -g 0 1 -100 100 0 0 0 NUM_POP 0 0 1000000 -2 0 0.5 FUNCTION_ARITY`
For spheres, `NUM_POP ` and `function_arity` should be equal

### Rosenbrock
`program.exe -v -g 7 1 -100 100 0 0 0 10 0 0 1000000 -2 0 0.5 10`
`program.exe -v -g 7 1 -100 100 0 0 0 NUM_POP 0 0 1000000 -2 0 0.5 FUNCTION_ARITY`
For Rosenbrock, `NUM_POP ` and `function_arity` should be equal

### Ellipsoids
`Program.exe -v -g 13 5 -5 5 0 0 1000 10 0 0 1000000 -2 0 0.5 50`
`Program.exe -v -g 13 5 -5 5 0 0 1000 POP 0 0 1000000 -2 0 0.5 FUNCTION_ARITY`
For Ellipsoids, FUNCTION_ARITY = 5 * POP.